### PR TITLE
Add -restore switch

### DIFF
--- a/Win11DisableRoundedCorners/Win11DisableRoundedCorners.c
+++ b/Win11DisableRoundedCorners/Win11DisableRoundedCorners.c
@@ -8,6 +8,11 @@ int main(int argc, char** argv)
 {
     BOOL bRestore = FALSE;
 
+    if (argc == 2 && strcmp(argv[1], "-restore") == 0)
+    {
+        bRestore = TRUE;
+    }
+
     char szTaskkill[MAX_PATH];
     ZeroMemory(
         szTaskkill,
@@ -50,7 +55,6 @@ int main(int argc, char** argv)
         MAX_PATH,
         "\\uDWM_win11drc.bak"
     );
-    bRestore = fileExists(szOriginalDWM);
 
     char szModifiedDWM[_MAX_PATH];
     ZeroMemory(


### PR DESCRIPTION
When Windows updates, this program tries to restore the original uDWM_win11drc.bak to uDWM.dll even though it should't, users have to manually delete this file to get rid of rounded corners again.

See: https://github.com/valinet/Win11DisableRoundedCorners/issues/35